### PR TITLE
Issues #2 (Batato metadata) and #48 (Downloading a specific chapter)

### DIFF
--- a/mangarack-component-core/src/providers/batoto/chapter.ts
+++ b/mangarack-component-core/src/providers/batoto/chapter.ts
@@ -17,7 +17,10 @@ export function createChapter(externalAddress: string, metadata: mio.IChapterMet
     pagesAsync: () => downloadPagesAsync(externalAddress),
     title: metadata.title,
     version: metadata.version,
-    volume: metadata.volume
+    volume: metadata.volume,
+    group: metadata.group,
+    language: metadata.language,
+    uploadDate: metadata.uploadDate
   };
 }
 

--- a/mangarack-component-core/src/providers/batoto/series.ts
+++ b/mangarack-component-core/src/providers/batoto/series.ts
@@ -132,10 +132,7 @@ function getChapters($: mio.IHtmlDocument): mio.IChapter[] {
 					results.push(createChapter(address, metadata));
 					foundMatch = true;
 				} else if( address.match('group') ) {
-					if( results[results.length-1].group.hasValue )
-						results[results.length-1].group = mio.option<string>(results[results.length-1].group.value + ' & ' + $(td).text());
-					else
-						results[results.length-1].group = mio.option<string>($(td).text());
+					results[results.length-1].group = mio.option<string>($(td).text());
 					foundMatch = true;
 				} else if( address.match('user') ) {
 					foundMatch = true;

--- a/mangarack-component-core/src/providers/batoto/series.ts
+++ b/mangarack-component-core/src/providers/batoto/series.ts
@@ -148,52 +148,9 @@ function getChapters($: mio.IHtmlDocument): mio.IChapter[] {
 		});
 		if( !foundMatch ) {
 			let possibleDate = $(td).text();
-			let matchArchive = possibleDate.match(/^(.*) \[A\]$/i);
-			if( matchArchive ) {
-				possibleDate = matchArchive[1];
-			}
-			let matchAMinute = possibleDate.match(/^A minute ago$/i); // Not seen
-			let matchRecentMinutes = possibleDate.match(/^(\d*) minutes ago$/i); // Seen
-			let matchAnHour = possibleDate.match(/^An hour ago$/i); // Seen
-			let matchRecentHours = possibleDate.match(/^(\d*) hours ago$/i); // Seen
-			let matchADay = possibleDate.match(/^A day ago$/i); // Seen
-			let matchRecentDays = possibleDate.match(/^(\d*) days ago$/i); // Seen
-			let matchAWeek = possibleDate.match(/^A week ago$/i); // Seen
-			let matchRecentWeeks = possibleDate.match(/^(\d*) weeks ago$/i); // Seen
-			if( matchAMinute ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - 60 * 1000);
-			} else if( matchRecentMinutes ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - +matchRecentMinutes[1] * 60 * 1000);
-			} else if( matchAnHour ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - 60 * 60 * 1000);
-			} else if( matchRecentHours ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - +matchRecentHours[1] * 60 * 60 * 1000);
-			} else if( matchADay ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - 24 * 60 * 60 * 1000);
-			} else if( matchRecentDays ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - +matchRecentDays[1] * 24 * 60 * 60 * 1000);
-			} else if( matchAWeek ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - 7 * 24 * 60 * 60 * 1000);
-			} else if( matchRecentWeeks ) {
-				results[results.length-1].uploadDate = mio.option<number>(Date.now() - +matchRecentWeeks[1] * 7 * 24 * 60 * 60 * 1000);
-			} else {
-				let pm = possibleDate.match(/^(.*) PM$/i);
-				let matchMidday = possibleDate.match(/^(.*) \- 12:\d\d PM$/i);
-				let matchAMPM = possibleDate.match(/^(.*) [AP]M$/i);
-				if( matchAMPM ) {
-					possibleDate = matchAMPM[1];
-				}
-				let matchRemoveDash = possibleDate.match(/^(.*) \- (.*)$/);
-				if( matchRemoveDash ) {
-					possibleDate = matchRemoveDash[1] + ' ' + matchRemoveDash[2];
-				}
-				let convertedDate = Date.parse(possibleDate);
-				if( !isNaN(convertedDate) ) {
-					if( pm && !matchMidday ) {
-						convertedDate += 12 * 60 * 60 * 1000;
-					}
-					results[results.length-1].uploadDate = mio.option<number>(convertedDate);
-				}
+			let convertedDate = getChapterDate(possibleDate);
+			if( convertedDate.hasValue ) {
+				results[results.length-1].uploadDate = convertedDate;
 			}
 		}
 	 });
@@ -244,4 +201,61 @@ function getType($: mio.IHtmlDocument): string {
   let text = $('td:contains(Type:)').next(mio.option<string>()).text();
   let match = text.match(/^(.*)\s+\(.*\)$/);
   return match ? match[1] : text;
+}
+
+/**
+ * Converts a string to a date, using the known
+ * formats from Batato.
+ * @param possibleDate The input string
+ * @return the date, if valid
+ */
+function getChapterDate( possibleDate: string ) : mio.IOption<number> {
+	let matchArchive = possibleDate.match(/^(.*) \[A\]$/i);
+	if( matchArchive ) {
+		possibleDate = matchArchive[1];
+	}
+	let matchAMinute = possibleDate.match(/^A minute ago$/i); // Not seen
+	let matchRecentMinutes = possibleDate.match(/^(\d*) minutes ago$/i); // Seen
+	let matchAnHour = possibleDate.match(/^An hour ago$/i); // Seen
+	let matchRecentHours = possibleDate.match(/^(\d*) hours ago$/i); // Seen
+	let matchADay = possibleDate.match(/^A day ago$/i); // Seen
+	let matchRecentDays = possibleDate.match(/^(\d*) days ago$/i); // Seen
+	let matchAWeek = possibleDate.match(/^A week ago$/i); // Seen
+	let matchRecentWeeks = possibleDate.match(/^(\d*) weeks ago$/i); // Seen
+	if( matchAMinute ) {
+		return mio.option<number>(Date.now() - 60 * 1000);
+	} else if( matchRecentMinutes ) {
+		return mio.option<number>(Date.now() - +matchRecentMinutes[1] * 60 * 1000);
+	} else if( matchAnHour ) {
+		return mio.option<number>(Date.now() - 60 * 60 * 1000);
+	} else if( matchRecentHours ) {
+		return mio.option<number>(Date.now() - +matchRecentHours[1] * 60 * 60 * 1000);
+	} else if( matchADay ) {
+		return mio.option<number>(Date.now() - 24 * 60 * 60 * 1000);
+	} else if( matchRecentDays ) {
+		return mio.option<number>(Date.now() - +matchRecentDays[1] * 24 * 60 * 60 * 1000);
+	} else if( matchAWeek ) {
+		return mio.option<number>(Date.now() - 7 * 24 * 60 * 60 * 1000);
+	} else if( matchRecentWeeks ) {
+		return mio.option<number>(Date.now() - +matchRecentWeeks[1] * 7 * 24 * 60 * 60 * 1000);
+	} else {
+		let pm = possibleDate.match(/^(.*) PM$/i);
+		let matchMidday = possibleDate.match(/^(.*) \- 12:\d\d PM$/i);
+		let matchAMPM = possibleDate.match(/^(.*) [AP]M$/i);
+		if( matchAMPM ) {
+			possibleDate = matchAMPM[1];
+		}
+		let matchRemoveDash = possibleDate.match(/^(.*) \- (.*)$/);
+		if( matchRemoveDash ) {
+			possibleDate = matchRemoveDash[1] + ' ' + matchRemoveDash[2];
+		}
+		let convertedDate = Date.parse(possibleDate);
+		if( !isNaN(convertedDate) ) {
+			if( pm && !matchMidday ) {
+				convertedDate += 12 * 60 * 60 * 1000;
+			}
+			return mio.option<number>(convertedDate);
+		}
+	}
+	return mio.option<number>();
 }

--- a/mangarack-component-core/src/providers/enhance.ts
+++ b/mangarack-component-core/src/providers/enhance.ts
@@ -12,7 +12,10 @@ export function enhance(chapters: mio.IChapter[]): mio.IChapter[] {
     number: estimateNumber(chapters, chapter),
     title: chapter.title,
     version: chapter.version,
-    volume: chapter.volume
+    volume: chapter.volume,
+    group: chapter.group,
+    language: chapter.language,
+    uploadDate: chapter.uploadDate
   });
 }
 

--- a/mangarack-component-core/src/providers/kissmanga/chapter.ts
+++ b/mangarack-component-core/src/providers/kissmanga/chapter.ts
@@ -16,7 +16,10 @@ export function createChapter(address: string, metadata: mio.IChapterMetadata): 
     pagesAsync: () => downloadPagesAsync(address),
     title: metadata.title,
     version: metadata.version,
-    volume: metadata.volume
+    volume: metadata.volume,
+    group: metadata.group,
+    language: metadata.language,
+    uploadDate: metadata.uploadDate
   };
 }
 

--- a/mangarack-component-core/src/providers/mangafox/chapter.ts
+++ b/mangarack-component-core/src/providers/mangafox/chapter.ts
@@ -16,7 +16,10 @@ export function createChapter(address: string, metadata: mio.IChapterMetadata): 
     pagesAsync: () => downloadPagesAsync(address),
     title: metadata.title,
     version: metadata.version,
-    volume: metadata.volume
+    volume: metadata.volume,
+    group: metadata.group,
+    language: metadata.language,
+    uploadDate: metadata.uploadDate
   };
 }
 

--- a/mangarack-component-core/src/providers/mangafox/series.ts
+++ b/mangarack-component-core/src/providers/mangafox/series.ts
@@ -100,7 +100,10 @@ function getChapters($: mio.IHtmlDocument): mio.IChapter[] {
             number: mio.option(numberMatch ? parseFloat(numberMatch[0]) : null),
             title: /^Read Onl?ine$/i.test(title) ? '' : title,
             version: mio.option<number>(),
-            volume: mio.option(parseFloat(match[1]))
+            volume: mio.option(parseFloat(match[1])),
+            group: mio.option<string>(),
+            language: mio.option<string>(),
+            uploadDate: mio.option<number>()
           }));
         }
       });

--- a/mangarack-component-core/src/providers/scan.ts
+++ b/mangarack-component-core/src/providers/scan.ts
@@ -42,7 +42,10 @@ function createMetadata(match: RegExpMatchArray): mio.IChapterMetadata {
     number: mio.option(createNumber(match[2], match[4])),
     title: match[5] ? match[5].trim() : '',
     version: mio.option(parseFloat(match[3])),
-    volume: mio.option(parseFloat(match[1]))
+    volume: mio.option(parseFloat(match[1])),
+    group: mio.option<string>(),
+    language: mio.option<string>(),
+    uploadDate: mio.option<number>()
   };
 }
 

--- a/mangarack-component-core/src/typings/providers/IChapterMetadata.ts
+++ b/mangarack-component-core/src/typings/providers/IChapterMetadata.ts
@@ -23,4 +23,16 @@ export interface IChapterMetadata {
    * Contains the volume.
    */
   volume: mio.IOption<number>;
+  /**
+   * Contains the scanning group.
+   */
+  group: mio.IOption<string>;
+  /**
+   * Contains the scanlation language.
+   */
+  language: mio.IOption<string>;
+  /**
+   * Contains the upload date.
+   */
+  uploadDate: mio.IOption<number>;
 }

--- a/mangarack-runnable-cli/src/services/downloadService.ts
+++ b/mangarack-runnable-cli/src/services/downloadService.ts
@@ -165,9 +165,19 @@ function passesChapterFilter(chapter: mio.IChapter): boolean {
     return false;
   } else if( toChapter.length > 0 && chapter.number.value > Number(toChapter) ) {
     return false;
-  } else {
-    return true;
-  }
+	}
+	let fromDate = Date.parse(mio.settingService.getString('runnable.cli.filter.uploaddate.from'));
+	let toDate = Date.parse(mio.settingService.getString('runnable.cli.filter.uploaddate.to'));
+	if( !isNaN(fromDate) && chapter.uploadDate.hasValue && !isNaN(chapter.uploadDate.value) && chapter.uploadDate.value < fromDate ) {
+		return false;
+	} else if( !isNaN(toDate) && chapter.uploadDate.hasValue && !isNaN(chapter.uploadDate.value) && chapter.uploadDate.value > toDate ) {
+		return false;
+	}
+	let targetGroup = mio.settingService.getString('runnable.cli.filter.group');
+	if( targetGroup.length > 0 && chapter.group.hasValue && !chapter.group.value.match(targetGroup) ) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/mangarack-runnable-cli/src/services/downloadService.ts
+++ b/mangarack-runnable-cli/src/services/downloadService.ts
@@ -116,10 +116,20 @@ function getChapterName(series: mio.ISeries, chapter: mio.IChapter): mio.IOption
     let title = getSeriesName(series);
     if (!title.hasValue) {
       return mio.option<string>();
-    } else if (!chapter.volume.hasValue) {
-      return mio.option(`${title.value} #${format(3, chapter.number.value)}.cbz`);
     } else {
-      return mio.option(`${title.value} V${format(2, chapter.volume.value)} #${format(3, chapter.number.value)}.cbz`);
+			let chapterName = title.value;
+			if( chapter.volume.hasValue ) {
+				chapterName += ` V${format(2, chapter.volume.value)}`;
+			}
+			chapterName += ` #${format(3, chapter.number.value)}`;
+			if( mio.settingService.getBoolean('runnable.cli.filename.addLanguage') && chapter.language.hasValue ) {
+				chapterName += ` (${chapter.language.value})`;
+			}
+			if( mio.settingService.getBoolean('runnable.cli.filename.addGroup') && chapter.group.hasValue ) {
+				chapterName += ` [${chapter.group.value}]`;
+			}
+			chapterName += '.cbz';
+			return mio.option(chapterName);
     }
   }
 }

--- a/mangarack-runnable-cli/src/services/downloadService.ts
+++ b/mangarack-runnable-cli/src/services/downloadService.ts
@@ -126,7 +126,7 @@ function getChapterName(series: mio.ISeries, chapter: mio.IChapter): mio.IOption
 				chapterName += ` (${chapter.language.value})`;
 			}
 			if( mio.settingService.getBoolean('runnable.cli.filename.addGroup') && chapter.group.hasValue ) {
-				chapterName += ` [${chapter.group.value}]`;
+				chapterName += ` [${chapter.group.value.replace(/[:\\\\/*?|<>]/g, '_').replace(/\p{Cntrl}/g, '_')}]`;
 			}
 			chapterName += '.cbz';
 			return mio.option(chapterName);

--- a/mangarack-runnable-cli/src/services/metaService.ts
+++ b/mangarack-runnable-cli/src/services/metaService.ts
@@ -1,6 +1,219 @@
 import * as mio from '../default';
 import * as xml2js from 'xml2js';
 
+/* From http://stackoverflow.com/questions/3217492/list-of-language-codes-in-yaml-or-json/4900304#4900304 */
+var langMap = JSON.parse(JSON.stringify(
+	[
+      {"code":"ab","name":"Abkhaz","nativeName":"аҧсуа"},
+      {"code":"aa","name":"Afar","nativeName":"Afaraf"},
+      {"code":"af","name":"Afrikaans","nativeName":"Afrikaans"},
+      {"code":"ak","name":"Akan","nativeName":"Akan"},
+      {"code":"sq","name":"Albanian","nativeName":"Shqip"},
+      {"code":"am","name":"Amharic","nativeName":"አማርኛ"},
+      {"code":"ar","name":"Arabic","nativeName":"العربية"},
+      {"code":"an","name":"Aragonese","nativeName":"Aragonés"},
+      {"code":"hy","name":"Armenian","nativeName":"Հայերեն"},
+      {"code":"as","name":"Assamese","nativeName":"অসমীয়া"},
+      {"code":"av","name":"Avaric","nativeName":"авар мацӀ, магӀарул мацӀ"},
+      {"code":"ae","name":"Avestan","nativeName":"avesta"},
+      {"code":"ay","name":"Aymara","nativeName":"aymar aru"},
+      {"code":"az","name":"Azerbaijani","nativeName":"azərbaycan dili"},
+      {"code":"bm","name":"Bambara","nativeName":"bamanankan"},
+      {"code":"ba","name":"Bashkir","nativeName":"башҡорт теле"},
+      {"code":"eu","name":"Basque","nativeName":"euskara, euskera"},
+      {"code":"be","name":"Belarusian","nativeName":"Беларуская"},
+      {"code":"bn","name":"Bengali","nativeName":"বাংলা"},
+      {"code":"bh","name":"Bihari","nativeName":"भोजपुरी"},
+      {"code":"bi","name":"Bislama","nativeName":"Bislama"},
+      {"code":"bs","name":"Bosnian","nativeName":"bosanski jezik"},
+      {"code":"br","name":"Breton","nativeName":"brezhoneg"},
+      {"code":"bg","name":"Bulgarian","nativeName":"български език"},
+      {"code":"my","name":"Burmese","nativeName":"ဗမာစာ"},
+      {"code":"ca","name":"Catalan; Valencian","nativeName":"Català"},
+      {"code":"ch","name":"Chamorro","nativeName":"Chamoru"},
+      {"code":"ce","name":"Chechen","nativeName":"нохчийн мотт"},
+      {"code":"ny","name":"Chichewa; Chewa; Nyanja","nativeName":"chiCheŵa, chinyanja"},
+      {"code":"zh","name":"Chinese","nativeName":"中文 (Zhōngwén), 汉语, 漢語"},
+      {"code":"cv","name":"Chuvash","nativeName":"чӑваш чӗлхи"},
+      {"code":"kw","name":"Cornish","nativeName":"Kernewek"},
+      {"code":"co","name":"Corsican","nativeName":"corsu, lingua corsa"},
+      {"code":"cr","name":"Cree","nativeName":"ᓀᐦᐃᔭᐍᐏᐣ"},
+      {"code":"hr","name":"Croatian","nativeName":"hrvatski"},
+      {"code":"cs","name":"Czech","nativeName":"česky, čeština"},
+      {"code":"da","name":"Danish","nativeName":"dansk"},
+      {"code":"dv","name":"Divehi; Dhivehi; Maldivian;","nativeName":"ދިވެހި"},
+      {"code":"nl","name":"Dutch","nativeName":"Nederlands, Vlaams"},
+      {"code":"en","name":"English","nativeName":"English"},
+      {"code":"eo","name":"Esperanto","nativeName":"Esperanto"},
+      {"code":"et","name":"Estonian","nativeName":"eesti, eesti keel"},
+      {"code":"ee","name":"Ewe","nativeName":"Eʋegbe"},
+      {"code":"fo","name":"Faroese","nativeName":"føroyskt"},
+      {"code":"fj","name":"Fijian","nativeName":"vosa Vakaviti"},
+      {"code":"fi","name":"Finnish","nativeName":"suomi, suomen kieli"},
+      {"code":"fr","name":"French","nativeName":"français, langue française"},
+      {"code":"ff","name":"Fula; Fulah; Pulaar; Pular","nativeName":"Fulfulde, Pulaar, Pular"},
+      {"code":"gl","name":"Galician","nativeName":"Galego"},
+      {"code":"ka","name":"Georgian","nativeName":"ქართული"},
+      {"code":"de","name":"German","nativeName":"Deutsch"},
+      {"code":"el","name":"Greek, Modern","nativeName":"Ελληνικά"},
+      {"code":"gn","name":"Guaraní","nativeName":"Avañeẽ"},
+      {"code":"gu","name":"Gujarati","nativeName":"ગુજરાતી"},
+      {"code":"ht","name":"Haitian; Haitian Creole","nativeName":"Kreyòl ayisyen"},
+      {"code":"ha","name":"Hausa","nativeName":"Hausa, هَوُسَ"},
+      {"code":"he","name":"Hebrew (modern)","nativeName":"עברית"},
+      {"code":"hz","name":"Herero","nativeName":"Otjiherero"},
+      {"code":"hi","name":"Hindi","nativeName":"हिन्दी, हिंदी"},
+      {"code":"ho","name":"Hiri Motu","nativeName":"Hiri Motu"},
+      {"code":"hu","name":"Hungarian","nativeName":"Magyar"},
+      {"code":"ia","name":"Interlingua","nativeName":"Interlingua"},
+      {"code":"id","name":"Indonesian","nativeName":"Bahasa Indonesia"},
+      {"code":"ie","name":"Interlingue","nativeName":"Originally called Occidental; then Interlingue after WWII"},
+      {"code":"ga","name":"Irish","nativeName":"Gaeilge"},
+      {"code":"ig","name":"Igbo","nativeName":"Asụsụ Igbo"},
+      {"code":"ik","name":"Inupiaq","nativeName":"Iñupiaq, Iñupiatun"},
+      {"code":"io","name":"Ido","nativeName":"Ido"},
+      {"code":"is","name":"Icelandic","nativeName":"Íslenska"},
+      {"code":"it","name":"Italian","nativeName":"Italiano"},
+      {"code":"iu","name":"Inuktitut","nativeName":"ᐃᓄᒃᑎᑐᑦ"},
+      {"code":"ja","name":"Japanese","nativeName":"日本語 (にほんご／にっぽんご)"},
+      {"code":"jv","name":"Javanese","nativeName":"basa Jawa"},
+      {"code":"kl","name":"Kalaallisut, Greenlandic","nativeName":"kalaallisut, kalaallit oqaasii"},
+      {"code":"kn","name":"Kannada","nativeName":"ಕನ್ನಡ"},
+      {"code":"kr","name":"Kanuri","nativeName":"Kanuri"},
+      {"code":"ks","name":"Kashmiri","nativeName":"कश्मीरी, كشميري‎"},
+      {"code":"kk","name":"Kazakh","nativeName":"Қазақ тілі"},
+      {"code":"km","name":"Khmer","nativeName":"ភាសាខ្មែរ"},
+      {"code":"ki","name":"Kikuyu, Gikuyu","nativeName":"Gĩkũyũ"},
+      {"code":"rw","name":"Kinyarwanda","nativeName":"Ikinyarwanda"},
+      {"code":"ky","name":"Kirghiz, Kyrgyz","nativeName":"кыргыз тили"},
+      {"code":"kv","name":"Komi","nativeName":"коми кыв"},
+      {"code":"kg","name":"Kongo","nativeName":"KiKongo"},
+      {"code":"ko","name":"Korean","nativeName":"한국어 (韓國語), 조선말 (朝鮮語)"},
+      {"code":"ku","name":"Kurdish","nativeName":"Kurdî, كوردی‎"},
+      {"code":"kj","name":"Kwanyama, Kuanyama","nativeName":"Kuanyama"},
+      {"code":"la","name":"Latin","nativeName":"latine, lingua latina"},
+      {"code":"lb","name":"Luxembourgish, Letzeburgesch","nativeName":"Lëtzebuergesch"},
+      {"code":"lg","name":"Luganda","nativeName":"Luganda"},
+      {"code":"li","name":"Limburgish, Limburgan, Limburger","nativeName":"Limburgs"},
+      {"code":"ln","name":"Lingala","nativeName":"Lingála"},
+      {"code":"lo","name":"Lao","nativeName":"ພາສາລາວ"},
+      {"code":"lt","name":"Lithuanian","nativeName":"lietuvių kalba"},
+      {"code":"lu","name":"Luba-Katanga","nativeName":""},
+      {"code":"lv","name":"Latvian","nativeName":"latviešu valoda"},
+      {"code":"gv","name":"Manx","nativeName":"Gaelg, Gailck"},
+      {"code":"mk","name":"Macedonian","nativeName":"македонски јазик"},
+      {"code":"mg","name":"Malagasy","nativeName":"Malagasy fiteny"},
+      {"code":"ms","name":"Malay","nativeName":"bahasa Melayu, بهاس ملايو‎"},
+      {"code":"ml","name":"Malayalam","nativeName":"മലയാളം"},
+      {"code":"mt","name":"Maltese","nativeName":"Malti"},
+      {"code":"mi","name":"Māori","nativeName":"te reo Māori"},
+      {"code":"mr","name":"Marathi (Marāṭhī)","nativeName":"मराठी"},
+      {"code":"mh","name":"Marshallese","nativeName":"Kajin M̧ajeļ"},
+      {"code":"mn","name":"Mongolian","nativeName":"монгол"},
+      {"code":"na","name":"Nauru","nativeName":"Ekakairũ Naoero"},
+      {"code":"nv","name":"Navajo, Navaho","nativeName":"Diné bizaad, Dinékʼehǰí"},
+      {"code":"nb","name":"Norwegian Bokmål","nativeName":"Norsk bokmål"},
+      {"code":"nd","name":"North Ndebele","nativeName":"isiNdebele"},
+      {"code":"ne","name":"Nepali","nativeName":"नेपाली"},
+      {"code":"ng","name":"Ndonga","nativeName":"Owambo"},
+      {"code":"nn","name":"Norwegian Nynorsk","nativeName":"Norsk nynorsk"},
+      {"code":"no","name":"Norwegian","nativeName":"Norsk"},
+      {"code":"ii","name":"Nuosu","nativeName":"ꆈꌠ꒿ Nuosuhxop"},
+      {"code":"nr","name":"South Ndebele","nativeName":"isiNdebele"},
+      {"code":"oc","name":"Occitan","nativeName":"Occitan"},
+      {"code":"oj","name":"Ojibwe, Ojibwa","nativeName":"ᐊᓂᔑᓈᐯᒧᐎᓐ"},
+      {"code":"cu","name":"Old Church Slavonic, Church Slavic, Church Slavonic, Old Bulgarian, Old Slavonic","nativeName":"ѩзыкъ словѣньскъ"},
+      {"code":"om","name":"Oromo","nativeName":"Afaan Oromoo"},
+      {"code":"or","name":"Oriya","nativeName":"ଓଡ଼ିଆ"},
+      {"code":"os","name":"Ossetian, Ossetic","nativeName":"ирон æвзаг"},
+      {"code":"pa","name":"Panjabi, Punjabi","nativeName":"ਪੰਜਾਬੀ, پنجابی‎"},
+      {"code":"pi","name":"Pāli","nativeName":"पाऴि"},
+      {"code":"fa","name":"Persian","nativeName":"فارسی"},
+      {"code":"pl","name":"Polish","nativeName":"polski"},
+      {"code":"ps","name":"Pashto, Pushto","nativeName":"پښتو"},
+      {"code":"pt","name":"Portuguese","nativeName":"Português"},
+      {"code":"qu","name":"Quechua","nativeName":"Runa Simi, Kichwa"},
+      {"code":"rm","name":"Romansh","nativeName":"rumantsch grischun"},
+      {"code":"rn","name":"Kirundi","nativeName":"kiRundi"},
+      {"code":"ro","name":"Romanian, Moldavian, Moldovan","nativeName":"română"},
+      {"code":"ru","name":"Russian","nativeName":"русский язык"},
+      {"code":"sa","name":"Sanskrit (Saṁskṛta)","nativeName":"संस्कृतम्"},
+      {"code":"sc","name":"Sardinian","nativeName":"sardu"},
+      {"code":"sd","name":"Sindhi","nativeName":"सिन्धी, سنڌي، سندھی‎"},
+      {"code":"se","name":"Northern Sami","nativeName":"Davvisámegiella"},
+      {"code":"sm","name":"Samoan","nativeName":"gagana faa Samoa"},
+      {"code":"sg","name":"Sango","nativeName":"yângâ tî sängö"},
+      {"code":"sr","name":"Serbian","nativeName":"српски језик"},
+      {"code":"gd","name":"Scottish Gaelic; Gaelic","nativeName":"Gàidhlig"},
+      {"code":"sn","name":"Shona","nativeName":"chiShona"},
+      {"code":"si","name":"Sinhala, Sinhalese","nativeName":"සිංහල"},
+      {"code":"sk","name":"Slovak","nativeName":"slovenčina"},
+      {"code":"sl","name":"Slovene","nativeName":"slovenščina"},
+      {"code":"so","name":"Somali","nativeName":"Soomaaliga, af Soomaali"},
+      {"code":"st","name":"Southern Sotho","nativeName":"Sesotho"},
+      {"code":"es","name":"Spanish; Castilian","nativeName":"español, castellano"},
+      {"code":"su","name":"Sundanese","nativeName":"Basa Sunda"},
+      {"code":"sw","name":"Swahili","nativeName":"Kiswahili"},
+      {"code":"ss","name":"Swati","nativeName":"SiSwati"},
+      {"code":"sv","name":"Swedish","nativeName":"svenska"},
+      {"code":"ta","name":"Tamil","nativeName":"தமிழ்"},
+      {"code":"te","name":"Telugu","nativeName":"తెలుగు"},
+      {"code":"tg","name":"Tajik","nativeName":"тоҷикӣ, toğikī, تاجیکی‎"},
+      {"code":"th","name":"Thai","nativeName":"ไทย"},
+      {"code":"ti","name":"Tigrinya","nativeName":"ትግርኛ"},
+      {"code":"bo","name":"Tibetan Standard, Tibetan, Central","nativeName":"བོད་ཡིག"},
+      {"code":"tk","name":"Turkmen","nativeName":"Türkmen, Түркмен"},
+      {"code":"tl","name":"Tagalog","nativeName":"Wikang Tagalog, ᜏᜒᜃᜅ᜔ ᜆᜄᜎᜓᜄ᜔"},
+      {"code":"tn","name":"Tswana","nativeName":"Setswana"},
+      {"code":"to","name":"Tonga (Tonga Islands)","nativeName":"faka Tonga"},
+      {"code":"tr","name":"Turkish","nativeName":"Türkçe"},
+      {"code":"ts","name":"Tsonga","nativeName":"Xitsonga"},
+      {"code":"tt","name":"Tatar","nativeName":"татарча, tatarça, تاتارچا‎"},
+      {"code":"tw","name":"Twi","nativeName":"Twi"},
+      {"code":"ty","name":"Tahitian","nativeName":"Reo Tahiti"},
+      {"code":"ug","name":"Uighur, Uyghur","nativeName":"Uyƣurqə, ئۇيغۇرچە‎"},
+      {"code":"uk","name":"Ukrainian","nativeName":"українська"},
+      {"code":"ur","name":"Urdu","nativeName":"اردو"},
+      {"code":"uz","name":"Uzbek","nativeName":"zbek, Ўзбек, أۇزبېك‎"},
+      {"code":"ve","name":"Venda","nativeName":"Tshivenḓa"},
+      {"code":"vi","name":"Vietnamese","nativeName":"Tiếng Việt"},
+      {"code":"vo","name":"Volapük","nativeName":"Volapük"},
+      {"code":"wa","name":"Walloon","nativeName":"Walon"},
+      {"code":"cy","name":"Welsh","nativeName":"Cymraeg"},
+      {"code":"wo","name":"Wolof","nativeName":"Wollof"},
+      {"code":"fy","name":"Western Frisian","nativeName":"Frysk"},
+      {"code":"xh","name":"Xhosa","nativeName":"isiXhosa"},
+      {"code":"yi","name":"Yiddish","nativeName":"ייִדיש"},
+      {"code":"yo","name":"Yoruba","nativeName":"Yorùbá"},
+      {"code":"za","name":"Zhuang, Chuang","nativeName":"Saɯ cueŋƅ, Saw cuengh"}
+]
+));
+
+function getLanguageName (languageCode : string) {
+    for( var i = 0 ; i < langMap.length; i++ ) {
+			if( langMap[i].code == languageCode ) {
+				return langMap[i].name;
+			}
+    }
+    return languageCode;
+}
+
+function getLanguageCode (languageName : string) {
+    /* exact match */
+    for( var i = 0 ; i < langMap.length; i++ ) {
+			if( langMap[i].name == languageName ) {
+				return langMap[i].code;
+			}
+    }
+    /* partial match */
+    for( var i = 0 ; i < langMap.length; i++ ) {
+			if( langMap[i].name.indexOf(languageName) != -1 ) {
+				return langMap[i].code;
+			}
+    }
+    return languageName;
+}
+
 /**
  * Represents the meta service.
  */
@@ -16,18 +229,20 @@ export let metaService: mio.IMetaService = {
     return new xml2js.Builder({
       rootName: 'ComicInfo',
       xmldec: {version: '1.0', encoding: 'utf-8'}
-    }).buildObject(titleCase({
-      genres: series.genres.map(genre => mio.GenreType[genre].replace(/([a-z])([A-Z])/g, '$1 $2')).join(', '),
-      manga: series.type === mio.SeriesType.Manga ? 'YesAndRightToLeft' : '',
-      number: chapter.number.hasValue ? String(chapter.number.value) : '',
-      pages: {page: [{image: 0, type: 'FrontCover'}].concat(pages.map(page => ({image: page.number, type: ''})))},
-      penciller: series.artists.join(', '),
-      series: series.title,
-      summary: series.summary,
-      title: chapter.title,
-      volume: chapter.volume.hasValue ? String(chapter.volume.value) : mio.settingService.getString('runnable.cli.metaUnknownVolume'),
-      writer: series.authors.join(', ')
-    }));
+    }).buildObject({
+      Genres: series.genres.map(genre => mio.GenreType[genre].replace(/([a-z])([A-Z])/g, '$1 $2')).join(', '),
+			LanguageISO: chapter.language.hasValue ? getLanguageCode(String(chapter.language.value)) : '',
+      Manga: series.type === mio.SeriesType.Manga ? 'YesAndRightToLeft' : '',
+      Number: chapter.number.hasValue ? String(chapter.number.value) : '',
+      Pages: {page: [{image: 0, type: 'FrontCover'}].concat(pages.map(page => ({image: page.number, type: ''})))},
+      Penciller: series.artists.join(', '),
+			ScanInformation: chapter.group.hasValue ? String(chapter.group.value) : '',
+      Series: series.title,
+      Summary: series.summary,
+      Title: chapter.title,
+      Volume: chapter.volume.hasValue ? String(chapter.volume.value) : mio.settingService.getString('runnable.cli.metaUnknownVolume'),
+      Writer: series.authors.join(', ')
+    });
   }
 };
 


### PR DESCRIPTION
- Adds language, group and uploadDate to IChapterMetadata.
These are only populated for Batato, left blank for other sources.
- Adds commandline options --runnable.cli.filter.chapter.single --runnable.cli.filter.chapter.from and --runnable.cli.filter.chapter.to to limit which chapters are downloaded (from and to are inclusive).
These work from any sources, not just Batato
- Adds commandline option --runnable.cli.filter.group to download only chapters from the specified group (Batato only)
- Adds commandline option --runnable.cli.filter.language to download only chapter from a single language (English, French,...), or all languages (All). If omitted, defaults to English, as previously. (Batato only)
- Adds commandline options --runnable.cli.filter.uploaddate.from and --runable.cli.filter.uploaddate.to to limit chapters to only those uploaded between the specified dates (inclusive).  (Batato only)
- Adds commandline option --runnable.cli.dryRun to prevent files from actually being downloaded, so that you can see what would be selected by the current filters.
- Adds commandline options --runnable.cli.filename.addLanguage and --runnable.cli.filename.addGroup to add the specified elements to the downloaded filename. Filename is "Title Vvolume #chapter (language) [group].cbz". (Batato only)
- Adds language and group to ComicRack.xml file. Had to manually title case xml tags, as ComicRack requires exact case for ScanInformation (checked). Had to convert language from name to ISO code (checked).

General comments: I'm not a JavaScript programmer, and I think my changes could be improved a lot, especially the html parsing, but I think everything does work, and in a reasonably sensible and consistent way.